### PR TITLE
Update README to Inform About Official OVH OpenAPI Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# How to use
+# ovh sdk .net
+This repository provides a client to interact with the OVH API. However, please note that OVH already provides an official OpenAPI 3 specification for their API, so you can skip any manual generation of specs and directly leverage this in your tooling!
+
+## Official OpenAPI Spec:
+You can find the official OVH OpenAPI 3 specification here:
+[OVH API OpenAPI 3 Spec](https://eu.api.ovh.com/1.0/cloud.json?format=openapi3)
+
+You can use this OpenAPI spec with any OpenAPI-compatible tools to generate clients for various programming languages, or just explore the API documentation more easily.
+
+## How to use
 
 ```csharp
 using Ovh.Sdk.Net;


### PR DESCRIPTION
This PR updates the README to inform users about the official OVH OpenAPI 3 specification provided by OVH. The purpose is to help developers avoid unnecessary work generating OpenAPI specs for the OVH API, as OVH already provides this in a ready-to-use format.

